### PR TITLE
<link> est reservé: chgmt de nom pour <vgo_url>

### DIFF
--- a/VegoResto/UserData.swift
+++ b/VegoResto/UserData.swift
@@ -119,7 +119,7 @@ class UserData: NSObject, CLLocationManagerDelegate {
             let longitude = elem["lon"].element?.text
             let website = elem["site_internet"].element?.text
             let phone = elem["tel_fixe"].element?.text
-            let link = elem["link"].element?.text
+            let link = elem["vgo_url"].element?.text
             let identifer = elem["id"].element?.text
             let ville = elem["ville"].element?.text
             let resume = elem["description"].element?.text


### PR DESCRIPTION
link.text n'est pas possible dans de nombreuses API de manipulation XML (balise autofermante)

Nous avons intérêt à conserver des sémantiques identiques entre le JSON et le XML (aussi longtemps que possible).
- `<link>` va donc devenir `<vgo_url>` (déjà le cas pour le XML)
- `<vego_url>` va devenir `<vgo_slug>` par soucis de cohérence (déjà le cas pour le XML)
